### PR TITLE
Create readonly.html

### DIFF
--- a/readonly.html
+++ b/readonly.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./node_modules/blockly/blockly_compressed.js"></script>
+  <script src="./node_modules/blockly/blocks_compressed.js"></script>
+  <script src="./node_modules/blockly/javascript_compressed.js"></script>
+  <script src="./node_modules/blockly/msg/js/en.js"></script>
+  <style>
+    body {
+      background-color: #444;
+    }
+  </style>
+</head>
+<body>
+  <div id="blocklyDiv" style="height: 400px; width: 500px;"></div>
+  <xml id="startBlocks" style="display: none">
+    <block type="controls_if" inline="false" x="20" y="20">
+      <mutation else="1"></mutation>
+      <value name="IF0">
+        <block type="logic_compare" inline="true">
+          <field name="OP">EQ</field>
+          <value name="A">
+            <block type="math_number">
+              <field name="NUM">45</field>
+            </block>
+          </value>
+          <value name="B">
+            <block type="math_number">
+              <field name="NUM">42</field>
+            </block>
+          </value>
+        </block>
+      </value>
+      <statement name="DO0">
+        <block type="text_print" inline="false">
+          <value name="TEXT">
+            <block type="text">
+              <field name="TEXT">Something</field>
+            </block>
+          </value>
+        </block>
+      </statement>
+      <statement name="ELSE">
+        <block type="text_print" inline="false">
+          <value name="TEXT">
+            <block type="text">
+              <field name="TEXT">Something Else</field>
+            </block>
+          </value>
+        </block>
+      </statement>
+    </block>
+  </xml>
+
+  <script>
+    var demoWorkspace = Blockly.inject('blocklyDiv',
+        {media: '../../media/',
+         readOnly: true});
+
+    Blockly.Xml.domToWorkspace(document.getElementById('startBlocks'),
+                               demoWorkspace);
+    const boundingBox = Blockly.getMainWorkspace().getBlocksBoundingBox();
+    document.getElementById('blocklyDiv').style.height=(boundingBox.height) + "px";
+    document.getElementById('blocklyDiv').style.width=(boundingBox.width) + "px";
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
Sample page for creating readonly blocks to be displayed inline
Currently:
- Sets the readOnly option so that user cannot interact with rendered blocks
- Div size is set to dimensions of the block.
Not yet done:
- Remove padding from top and left so that the block fits in its bounding box
- Display inline with text