### PR TITLE
Add style inline-block to blockly div

### DIFF
--- a/readonly.html
+++ b/readonly.html
@@ -9,11 +9,19 @@
   <style>
     body {
       background-color: #444;
+      color: #fff;
     }
   </style>
 </head>
 <body>
-  <div id="blocklyDiv" style="height: 400px; width: 500px;"></div>
+  This is some text before the block
+    <div id="blocklyDiv" style="height: 400px; width: 500px; display: inline-block;"></div>
+  and this is some text after the block
+  <xml id="smallBlock" style="display: none">
+    <block type="math_number">
+      <field name="NUM">12345</field>
+    </block>
+  </xml>
   <xml id="startBlocks" style="display: none">
     <block type="controls_if" inline="false" x="20" y="20">
       <mutation else="1"></mutation>
@@ -58,7 +66,7 @@
         {media: '../../media/',
          readOnly: true});
 
-    Blockly.Xml.domToWorkspace(document.getElementById('startBlocks'),
+    Blockly.Xml.domToWorkspace(document.getElementById('smallBlock'),
                                demoWorkspace);
     const boundingBox = Blockly.getMainWorkspace().getBlocksBoundingBox();
     document.getElementById('blocklyDiv').style.height=(boundingBox.height) + "px";


### PR DESCRIPTION
- Displays the block in line with text
Not yet done: Removing the padding from top and left
Also note: the puzzle-piece connector piece is rendered in negative space and not including in the size of the bounding box (relying on the padding being there), so we will need to account for that when we figure out how to remove the left padding
<img width="532" alt="screen shot 2019-02-15 at 1 30 09 pm" src="https://user-images.githubusercontent.com/8787187/52885373-d8102b00-3125-11e9-8407-c17f86839527.png">
